### PR TITLE
.save() uses transaction.atomic instead of savepoints

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -35,12 +35,10 @@ class TagBase(models.Model):
             while True:
                 i += 1
                 try:
-                    sid = transaction.savepoint(**trans_kwargs)
-                    res = super(TagBase, self).save(*args, **kwargs)
-                    transaction.savepoint_commit(sid, **trans_kwargs)
+                    with transaction.atomic():
+                        res = super(TagBase, self).save(*args, **kwargs)
                     return res
                 except IntegrityError:
-                    transaction.savepoint_rollback(sid, **trans_kwargs)
                     self.slug = self.slugify(self.name, i)
         else:
             return super(TagBase, self).save(*args, **kwargs)


### PR DESCRIPTION
ready to review?: Yes. 

Explained in more detail than you want or require here https://code.djangoproject.com/ticket/21134#no1

TL;DR Use transaction.atomic() instead of transaction.savepoint() and transaction.rollback() in Django 1.6 when you expect to continue and do something useful after a DatabaseError (or in this case a more specific IntegrityError)
